### PR TITLE
[Artist] 장르 정보 보완

### DIFF
--- a/src/main/java/com/back/web7_9_codecrete_be/domain/artists/controller/ArtistsController.java
+++ b/src/main/java/com/back/web7_9_codecrete_be/domain/artists/controller/ArtistsController.java
@@ -62,7 +62,7 @@ public class ArtistsController {
     public RsData<Void> create(
             @Valid @RequestBody CreateRequest reqBody
     ) {
-        artistService.createArtist(reqBody.artistName(), reqBody.artistGroup(), reqBody.artistType(), reqBody.genreName());
+        artistService.createArtist(reqBody.spotifyID(), reqBody.artistName(), reqBody.artistGroup(), reqBody.artistType(), reqBody.genreName());
         return RsData.success("아티스트 생성이 완료되었습니다.", null);
     }
 

--- a/src/main/java/com/back/web7_9_codecrete_be/domain/artists/dto/request/CreateRequest.java
+++ b/src/main/java/com/back/web7_9_codecrete_be/domain/artists/dto/request/CreateRequest.java
@@ -1,12 +1,18 @@
 package com.back.web7_9_codecrete_be.domain.artists.dto.request;
 
 import com.back.web7_9_codecrete_be.domain.artists.entity.ArtistType;
+import com.back.web7_9_codecrete_be.domain.artists.entity.Genre;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record CreateRequest(
+        @NotBlank
+        @Size(max = 30, message = "Spotify ID 는 필수로 입력해야합니다.")
+        @Schema(description = "Spotify ID 입니다.")
+        String spotifyID,
+
         @NotBlank(message = "아티스트 이름은 필수로 입력해야합니다.")
         @Size(max = 200, message = "아티스트 이름은 200자를 넘길 수 없습니다.")
         @Schema(description = "아티스트 이름입니다.")

--- a/src/main/java/com/back/web7_9_codecrete_be/domain/artists/dto/response/ArtistListResponse.java
+++ b/src/main/java/com/back/web7_9_codecrete_be/domain/artists/dto/response/ArtistListResponse.java
@@ -3,6 +3,8 @@ package com.back.web7_9_codecrete_be.domain.artists.dto.response;
 import com.back.web7_9_codecrete_be.domain.artists.entity.Artist;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.List;
+
 public record ArtistListResponse(
         @Schema(description = "아티스트 아이디입니다.")
         Long id,
@@ -13,8 +15,8 @@ public record ArtistListResponse(
         @Schema(description = "아티스트 소속 그룹입니다. 아티스트 이름이 그룹인 경우, null 로 처리됩니다.")
         String artistGroup,
 
-        @Schema(description = "장르 이름입니다.")
-        String genreName,
+        @Schema(description = "장르입니다.")
+        List<String> genres,
 
         @Schema(description = "받은 좋아요 수(찜한 사람 수) 입니다.")
         int likeCount,
@@ -25,12 +27,20 @@ public record ArtistListResponse(
         @Schema(description = "로그인한 유저의 좋아요 여부입니다. 비회원인 경우 false입니다.")
         Boolean isLiked
 ) {
+    public static List<String> getGenre(Artist artist) {
+        return artist.getArtistGenres().stream()
+                .map(ag -> ag.getGenre().getGenreName())
+                .distinct()
+                .toList();
+    }
+
     public static ArtistListResponse from(Artist artist) {
+        List<String> genres = getGenre(artist);
         return new ArtistListResponse(
                 artist.getId(),
                 artist.getArtistName(),
                 artist.getArtistGroup(),
-                artist.getGenre().getGenreName(),
+                genres,
                 artist.getLikeCount(),
                 artist.getImageUrl(),
                 false // 기본값은 false
@@ -38,11 +48,12 @@ public record ArtistListResponse(
     }
 
     public static ArtistListResponse from(Artist artist, boolean isLiked) {
+        List<String> genres = getGenre(artist);
         return new ArtistListResponse(
                 artist.getId(),
                 artist.getArtistName(),
                 artist.getArtistGroup(),
-                artist.getGenre().getGenreName(),
+                genres,
                 artist.getLikeCount(),
                 artist.getImageUrl(),
                 isLiked

--- a/src/main/java/com/back/web7_9_codecrete_be/domain/artists/entity/ArtistGenre.java
+++ b/src/main/java/com/back/web7_9_codecrete_be/domain/artists/entity/ArtistGenre.java
@@ -1,0 +1,29 @@
+package com.back.web7_9_codecrete_be.domain.artists.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArtistGenre {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "artist_genre_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "artist_id", nullable = false)
+    private Artist artist;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "genre_id", nullable = false)
+    private Genre genre;
+
+    public ArtistGenre(Artist artist, Genre genre) {
+        this.artist = artist;
+        this.genre = genre;
+    }
+}

--- a/src/main/java/com/back/web7_9_codecrete_be/domain/artists/entity/Genre.java
+++ b/src/main/java/com/back/web7_9_codecrete_be/domain/artists/entity/Genre.java
@@ -17,15 +17,8 @@ public class Genre {
     @Column(name = "genre_name", nullable = false, length = 30)
     private String genreName;
 
-    @Column(name = "genre_group", length = 30)
-    private String genreGroup;
 
-    @Column(name = "genre_memo")
-    private String genreMemo;
-
-    public Genre(String genreName, String genreGroup, String genreMemo) {
+    public Genre(String genreName) {
         this.genreName = genreName;
-        this.genreGroup = genreGroup;
-        this.genreMemo = genreMemo;
     }
 }

--- a/src/main/java/com/back/web7_9_codecrete_be/domain/artists/repository/ArtistRepository.java
+++ b/src/main/java/com/back/web7_9_codecrete_be/domain/artists/repository/ArtistRepository.java
@@ -12,6 +12,7 @@ import java.util.List;
 @Repository
 public interface ArtistRepository extends JpaRepository<Artist, Long> {
     boolean existsBySpotifyArtistId(String spotifyArtistId);
+    java.util.Optional<Artist> findBySpotifyArtistId(String spotifyArtistId);
     
     @Query("SELECT a FROM Artist a WHERE a.nameKo IS NULL ORDER BY a.id ASC")
     List<Artist> findByNameKoIsNullOrderByIdAsc(Pageable pageable);
@@ -23,7 +24,16 @@ public interface ArtistRepository extends JpaRepository<Artist, Long> {
     boolean existsByNameKo(String nameKo);
 
     List<Artist> findTop5ByArtistGroupAndIdNot(String artistGroup, long excludeId);
-    List<Artist> findTop5ByGenreIdAndIdNot(Long genreId, long excludeId);
+    
+    @Query("""
+        SELECT DISTINCT a FROM Artist a
+        JOIN a.artistGenres ag
+        WHERE ag.genre.id = :genreId AND a.id != :excludeId
+        ORDER BY a.likeCount DESC
+    """)
+    List<Artist> findTop5ByGenreIdAndIdNot(@org.springframework.data.repository.query.Param("genreId") Long genreId, 
+                                             @org.springframework.data.repository.query.Param("excludeId") long excludeId,
+                                             Pageable pageable);
 
     List<Artist> findAllByArtistNameContainingIgnoreCaseOrNameKoContainingIgnoreCase(String artistName1, String artistName2);
 

--- a/src/main/java/com/back/web7_9_codecrete_be/domain/artists/repository/GenreRepository.java
+++ b/src/main/java/com/back/web7_9_codecrete_be/domain/artists/repository/GenreRepository.java
@@ -4,9 +4,11 @@ import com.back.web7_9_codecrete_be.domain.artists.entity.Genre;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface GenreRepository extends JpaRepository<Genre, Long> {
     Optional<Genre> findByGenreName(String genreName);
+    List<Genre> findByGenreNameIn(List<String> genreNames);
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 연결해주세요.  
`Close #이슈번호` 를 쓰면 PR merge 시 자동으로 close 됩니다.

- Close #180 

## 🚀 PR 개요
> 이 PR이 어떤 변경을 포함하고 있는지 간단히 설명해주세요.

- 장르 테이블의 구조 수정(Artist - ArtistGenre - Genre) : 다대다 관계 구현을 위해 중간 테이블인 ArtistGenre 도입
- Genre 의 저장 방식 : Spotify API 를 통한 아티스트 저장할 때 해당 아티스트의 장르 리스트를 함께 저장


## 📌 변경 사항
> 주요 변경 내용을 체크리스트 형태로 정리해주세요.

- [ ] 기능 추가
- [x] 버그 수정
- [x] 리팩터링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정

## 🧪 테스트 방법
> 변경된 내용을 어떻게 테스트했는지 구체적으로 적어주세요.


## 📸 스크린샷 (선택)
> UI 변경 또는 시각적으로 확인할 수 있는 변경이 있다면 첨부해주세요.

<img width="431" height="727" alt="스크린샷 2025-12-24 오전 9 10 06" src="https://github.com/user-attachments/assets/1bb580d4-fbb6-499a-836e-d3a0641c216d" />

<img width="408" height="542" alt="스크린샷 2025-12-24 오전 9 10 40" src="https://github.com/user-attachments/assets/0e2036a5-1355-476f-be46-fbd14393bcb7" />


## ⚠️ 참고 사항
> 리뷰어가 알아야 할 사항이 있다면 자유롭게 작성해주세요.

테이블이 새로 추가되고, 기존 테이블의 구조가 변경되었습니다! ERD 에 반영해놓겠습니다.
