### PR TITLE
[Concert] 공연 예매 일자 저장 범위 수정

### DIFF
--- a/src/main/java/com/back/web7_9_codecrete_be/domain/concerts/service/ConcertService.java
+++ b/src/main/java/com/back/web7_9_codecrete_be/domain/concerts/service/ConcertService.java
@@ -232,8 +232,10 @@ public class ConcertService {
         Concert concert = findConcertByConcertId(concertTicketTimeSetRequest.getConcertId());
         LocalDateTime ticketTime = concertTicketTimeSetRequest.getTicketTime();
         LocalDateTime ticketEndTime = concertTicketTimeSetRequest.getTicketEndTime();
+
         if(ticketTime.isAfter(ticketEndTime)) throw new BusinessException(ConcertErrorCode.NOT_VALID_TICKETING_TIME);
-        if(ticketTime.isBefore(LocalDateTime.now())) throw new BusinessException(ConcertErrorCode.NOT_VALID_TICKETING_TIME);
+        if(ticketTime.isAfter(concert.getEndDate().atTime(LocalTime.MAX))) throw new BusinessException(ConcertErrorCode.CONCERT_TICKETING_TIME_IS_NOT_AFTER_CONCERT_END_DATE);
+        if(ticketEndTime.isAfter(concert.getEndDate().atTime(LocalTime.MAX))) throw new BusinessException(ConcertErrorCode.CONCERT_TICKETING_END_TIME_IS_NOT_AFTER_CONCERT_END_DATE);
 
         concert.ticketTimeSet(ticketTime, ticketEndTime);
         Concert savedConcert = concertRepository.save(concert);

--- a/src/main/java/com/back/web7_9_codecrete_be/global/error/code/ConcertErrorCode.java
+++ b/src/main/java/com/back/web7_9_codecrete_be/global/error/code/ConcertErrorCode.java
@@ -14,7 +14,9 @@ public enum ConcertErrorCode implements ErrorCode {
     KEYWORD_IS_NULL(HttpStatus.BAD_REQUEST,"C-102","검색 키워드를 입력해주세요."),
     LIKE_CONFLICT(HttpStatus.CONFLICT,"C-131","이미 좋아요를 누른 공연입니다."),
     NOT_FOUND_CONCERTLIKE(HttpStatus.NOT_FOUND,"C-130","좋아요를 누르지 않은 공연입니다."),
-    NOT_VALID_TICKETING_TIME(HttpStatus.BAD_REQUEST, "C-140","공연 예매 시간이 옳지 않습니다. 확인해 주십시오.")
+    NOT_VALID_TICKETING_TIME(HttpStatus.BAD_REQUEST, "C-140","공연 예매 시간이 옳지 않습니다. 확인해 주십시오."),
+    CONCERT_TICKETING_TIME_IS_NOT_AFTER_CONCERT_END_DATE(HttpStatus.BAD_REQUEST, "C-141", "공연 예매 시작 시간은 공연 시작 시간보다 이전이어야 합니다."),
+    CONCERT_TICKETING_END_TIME_IS_NOT_AFTER_CONCERT_END_DATE(HttpStatus.BAD_REQUEST,"C-142","공연 예매 종료 시간은 공연 시작 시간보다 이전이어야 합니다.")
     ;
 
     private final HttpStatus status;


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 연결해주세요.  
`Close #이슈번호` 를 쓰면 PR merge 시 자동으로 close 됩니다.

- Close #189 

## 🚀 PR 개요
> 이 PR이 어떤 변경을 포함하고 있는지 간단히 설명해주세요.

- 공연 예매일자가 현재 시간 이전으로 설정할 수 없던 오류를 수정했습니다.
- 공연 예매 일자가 공연 마지막 날 끝날까지 저장이 가능하게 제한하였습니다.


## 📌 변경 사항
> 주요 변경 내용을 체크리스트 형태로 정리해주세요.

- [ ] 기능 추가
- [X] 버그 수정
- [ ] 리팩터링
- [ ] 문서 업데이트
- [ ] 테스트 추가/수정

## 🧪 테스트 방법
> 변경된 내용을 어떻게 테스트했는지 구체적으로 적어주세요.

1. postman 통한 수제 테스트

## ⚠️ 참고 사항
> 리뷰어가 알아야 할 사항이 있다면 자유롭게 작성해주세요.

- 날짜 범위 체크만 해주세요~
